### PR TITLE
Add missing properties to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "d3-pre",
   "version": "1.3.0",
   "description": "Prerender SVGs with D3",
+  "repository": "fivethirtyeight/d3-pre",
   "main": "index.js",
   "scripts": {
     "test": "semistandard src/**/* && mocha test/test.js && mochify --transform brfs test/browser.js",
     "example-axis": "budo examples/v4.js -- -t [ browserify-css --autoInject=true ]"
   },
-  "author": "",
+  "author": "FiveThirtyEight",
   "license": "MIT",
-  "dependencies": {},
   "devDependencies": {
     "brfs": "^1.4.3",
     "browserify-css": "^0.9.1",


### PR DESCRIPTION
npm suggests that you should have `repository` and `author` fields if you want your package to be more reachable. Also, you don't need to specify any empty properties (such as `dependencies`), they're empty by default and it makes no sense to re-define them.
